### PR TITLE
Update ring_utilities.py

### DIFF
--- a/ring_utilities.py
+++ b/ring_utilities.py
@@ -81,7 +81,7 @@ def atoms_to_graph(atoms,index,max_ring):
             matrix[osites[o],t]=1
     # now we make the graph
     import networkx as nx
-    G = nx.from_numpy_matrix(matrix)
+    G = nx.from_numpy_array(matrix)
     # G.remove_nodes_from(delete)
     return G, large_atoms, repeat
 


### PR DESCRIPTION
It might be worth it to update `nx.from_numpy_matrix` to `nx.from_numpy_array`. It is my understanding that nx.from_numpy_matrix is [outdated from networkx 3.0]( https://networkx.org/documentation/stable/release/release_3.0.html)